### PR TITLE
add output executable name to build command in build instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ It's simple! Just follow these 3 easy steps:
    cd /opt
    git clone https://github.com/bepass-org/bepass-relay.git
    cd bepass-relay
-   CGO_ENABLED=0 go build -ldflags '-s -w' -trimpath *.go
+   CGO_ENABLED=0 go build -o relay -ldflags '-s -w' -trimpath *.go
    ```
 
 2. Make a systemd service for Bepass in **/etc/systemd/system/cfb.service**:


### PR DESCRIPTION
i tried to build the relay on my server based on the instructions, but no executable was created after build.
according to ```go help build```:
>When the command line specifies a single main package,
build writes the resulting executable to output.
Otherwise build compiles the packages but discards the results,
serving only as a check that the packages can be built.